### PR TITLE
Remove aws-sdk dependency.

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'state_machine', '= 1.1.2'
   s.add_dependency 'ffaker', '~> 1.12.0'
   s.add_dependency 'paperclip', '~> 2.7.0'
-  s.add_dependency 'aws-sdk', '~> 1.3.4'
   s.add_dependency 'ransack', '0.7.2'
   s.add_dependency 'activemerchant', '~> 1.34'
   s.add_dependency 'json', '>= 1.5.5'


### PR DESCRIPTION
This was removed in master, but not in our fork.

See: spree/spree#4965.
