### PR TITLE
Remove one promotion per product rule limitation.

### DIFF
--- a/promo/app/models/spree/promotion/rules/product.rb
+++ b/promo/app/models/spree/promotion/rules/product.rb
@@ -6,7 +6,6 @@ module Spree
     module Rules
       class Product < PromotionRule
         has_and_belongs_to_many :products, :class_name => '::Spree::Product', :join_table => 'spree_products_promotion_rules', :foreign_key => 'promotion_rule_id'
-        validate :only_one_promotion_per_product
 
         MATCH_POLICIES = %w(any all)
         preference :match_policy, :string, :default => MATCH_POLICIES.first
@@ -32,14 +31,6 @@ module Spree
         def product_ids_string=(s)
           self.product_ids = s.to_s.split(',').map(&:strip)
         end
-
-        private
-
-          def only_one_promotion_per_product
-            if Spree::Promotion::Rules::Product.all.map(&:products).flatten.uniq!
-              errors[:base] << "You can't create two promotions for the same product"
-            end
-          end
       end
     end
   end


### PR DESCRIPTION
This was earlier proposed in freerunningtech/spree#3 but closed because
it seemed dangerous. After looking more carefully at the issue involved
I think we can do this and it will help make promotions much more
flexible.
